### PR TITLE
fix: '원' 통화 표시를 trip의 currencyCode로 대체

### DIFF
--- a/src/actions/exchange.ts
+++ b/src/actions/exchange.ts
@@ -2,6 +2,19 @@
 import { createClient } from '../utils/supabase/server';
 import countryToCurrency from 'country-to-currency';
 
+export async function getCurrencyCode(tripId: number): Promise<string | null> {
+  const supabase = await createClient();
+  const { data: trip } = await supabase
+    .from('trips')
+    .select('countryCode')
+    .eq('id', tripId)
+    .maybeSingle();
+
+  if (!trip) return null;
+
+  return (countryToCurrency as Record<string, string>)[trip.countryCode] ?? null;
+}
+
 export async function getExchangeRate(tripId: number) {
   const supabase = await createClient();
   const { data: trip } = await supabase

--- a/src/app/spend-stats/page.tsx
+++ b/src/app/spend-stats/page.tsx
@@ -1,6 +1,7 @@
 import CategoryPieChart from '../../components/spend/CategoryPieChart';
 import DailyLineChart from '../../components/spend/DailyLineChart';
 import Image from 'next/image';
+import { getCurrencyCode } from '../../actions/exchange';
 
 interface SpendStatsPageProps {
   searchParams: Promise<{ tripId?: string }>;
@@ -11,6 +12,7 @@ export default async function spendStatsPage({ searchParams }: SpendStatsPagePro
   if (!tripId) {
     return <div>tripId가 없습니다.</div>;
   }
+  const currencyCode = (await getCurrencyCode(Number(tripId))) ?? '원';
   return (
     <div className="flex flex-col gap-20 p-6">
       <div>
@@ -18,14 +20,14 @@ export default async function spendStatsPage({ searchParams }: SpendStatsPagePro
           <Image src="/sparkle.svg" alt="반짝이이미지" width={32} height={32} className="w-8" />
           <span className="text-xl">카테고리별 통계</span>
         </div>
-        <CategoryPieChart tripId={tripId} />
+        <CategoryPieChart tripId={tripId} currencyCode={currencyCode} />
       </div>
       <div>
         <div className="flex items-center gap-2 mb-6">
           <Image src="/sparkle.svg" alt="반짝이이미지" width={32} height={32} className="w-8" />
           <span className="text-xl">데일리별 통계</span>
         </div>
-        <DailyLineChart tripId={tripId} />
+        <DailyLineChart tripId={tripId} currencyCode={currencyCode} />
       </div>
     </div>
   );

--- a/src/app/trips/[id]/page.tsx
+++ b/src/app/trips/[id]/page.tsx
@@ -4,6 +4,7 @@ import SpendList from '../../../components/spend/SpendList';
 import SpendSummary from '../../../components/spend/SpendSummary';
 import SpendActions from '../../../components/spend/SpendActions';
 import { getSpendByTrip } from '../../../actions/spends';
+import { getCurrencyCode } from '../../../actions/exchange';
 
 interface TripDetailPageProps {
   params: Promise<{ id: string }>;
@@ -13,8 +14,8 @@ interface TripDetailPageProps {
 export default async function TripDetailPage({ params, searchParams }: TripDetailPageProps) {
   const { id } = await params;
   const { day = 'all' } = await searchParams;
-  const data = await getSpendByTrip(id);
-
+  const [data, currencyCode] = await Promise.all([getSpendByTrip(id), getCurrencyCode(Number(id))]);
+  const currency = currencyCode ?? '원';
   if (!data.success || !data.tripInfo) {
     return <div>지출 내역을 불러올 수 없습니다.</div>;
   }
@@ -24,11 +25,11 @@ export default async function TripDetailPage({ params, searchParams }: TripDetai
   return (
     <div className="flex flex-col h-screen overflow-hidden">
       <div className="flex justify-between items-center px-1 sm:px-4 py-1 border-b">
-        <SpendSummary tripId={id} />
+        <SpendSummary tripId={id} currencyCode={currency} />
         <SpendActions tripId={id} />
       </div>
       <div className="flex-1 overflow-hidden pb-14">
-        <SpendList tripId={id} data={data} selectedDay={day} />
+        <SpendList tripId={id} data={data} selectedDay={day} currencyCode={currency} />
       </div>
       {!isAllTab && (
         <div className="fixed bottom-0 left-0 right-0">

--- a/src/components/spend/CategoryPieChart.tsx
+++ b/src/components/spend/CategoryPieChart.tsx
@@ -7,9 +7,10 @@ const COLORS = ['#0088FE', '#00C49F', '#FFBB28', '#FF8042', '#8884D8', '#82ca9d'
 
 interface CategoryPieChartProps {
   tripId: string;
+  currencyCode: string;
 }
 
-export default function CategoryPieChart({ tripId }: CategoryPieChartProps) {
+export default function CategoryPieChart({ tripId, currencyCode }: CategoryPieChartProps) {
   const [chartData, setChartData] = useState<{ name: string; value: number }[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -73,7 +74,9 @@ export default function CategoryPieChart({ tripId }: CategoryPieChartProps) {
           ))}
         </Pie>
         <Tooltip
-          formatter={(value?: number) => (value !== undefined ? `${value.toLocaleString()}원` : '')}
+          formatter={(value?: number) =>
+            value !== undefined ? `${value.toLocaleString()} ${currencyCode}` : ''
+          }
         />
         <Legend />
       </PieChart>

--- a/src/components/spend/DailyLineChart.tsx
+++ b/src/components/spend/DailyLineChart.tsx
@@ -13,9 +13,10 @@ import { getDailyStats } from '../../actions/spendStats';
 
 interface DailyLineChartProps {
   tripId: string;
+  currencyCode: string;
 }
 
-export default function DailyLineChart({ tripId }: DailyLineChartProps) {
+export default function DailyLineChart({ tripId, currencyCode }: DailyLineChartProps) {
   const [chartData, setChartData] = useState<{ date: string; amount: number }[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -63,7 +64,7 @@ export default function DailyLineChart({ tripId }: DailyLineChartProps) {
           <YAxis />
           <Tooltip
             formatter={(value: number | undefined) =>
-              value !== undefined ? `${value.toLocaleString()}원` : ''
+              value !== undefined ? `${value.toLocaleString()} ${currencyCode}` : ''
             }
             labelFormatter={(label) => `${label}`}
           />

--- a/src/components/spend/SpendItem.tsx
+++ b/src/components/spend/SpendItem.tsx
@@ -1,6 +1,12 @@
 import type { SpendRecord } from '../../type/spend';
 
-export default function SpendItem({ spend }: { spend: SpendRecord }) {
+export default function SpendItem({
+  spend,
+  currencyCode,
+}: {
+  spend: SpendRecord;
+  currencyCode: string;
+}) {
   return (
     <div className="bg-white border border-gray-100 rounded-lg p-3 mb-2 mx-3 hover:shadow-md transition">
       <div className="flex items-center">
@@ -16,7 +22,7 @@ export default function SpendItem({ spend }: { spend: SpendRecord }) {
         </div>
 
         <div className="flex-[1.5] px-2 text-right font-semibold text-primary-text text-sm">
-          {spend.amount.toLocaleString()}원
+          {spend.amount.toLocaleString()} {currencyCode}
         </div>
 
         <div className="flex-1 px-2 text-center">

--- a/src/components/spend/SpendList.tsx
+++ b/src/components/spend/SpendList.tsx
@@ -20,8 +20,9 @@ interface SpendListProps {
     };
   };
   selectedDay: string;
+  currencyCode: string;
 }
-export default function SpendList({ tripId, data, selectedDay }: SpendListProps) {
+export default function SpendList({ tripId, data, selectedDay, currencyCode }: SpendListProps) {
   const router = useRouter();
   const [currentDay, setCurrentDay] = useState(selectedDay);
 
@@ -55,7 +56,7 @@ export default function SpendList({ tripId, data, selectedDay }: SpendListProps)
       </div>
       <div className="flex-1 overflow-y-auto">
         {currentSpends?.map((spend: SpendRecord) => (
-          <SpendItem key={spend.id} spend={spend} />
+          <SpendItem key={spend.id} spend={spend} currencyCode={currencyCode} />
         ))}
       </div>
     </div>

--- a/src/components/spend/SpendSummary.tsx
+++ b/src/components/spend/SpendSummary.tsx
@@ -1,5 +1,11 @@
 import { createClient } from '../../utils/supabase/server';
-export default async function SpendSummary({ tripId }: { tripId: string }) {
+export default async function SpendSummary({
+  tripId,
+  currencyCode,
+}: {
+  tripId: string;
+  currencyCode: string;
+}) {
   const supabase = await createClient();
 
   //총 환전액
@@ -35,14 +41,14 @@ export default async function SpendSummary({ tripId }: { tripId: string }) {
         <span className="text-xs text-gray-600">남은 현금</span>
         <span className="text-md sm:text-lg font-bold text-primary-text">
           {remainCash.toLocaleString()}
-          <span className="hidden sm:inline">원</span>
+          <span className="hidden sm:inline"> {currencyCode}</span>
         </span>
       </div>
       <div className="flex items-center gap-1 sm:gap-2 px-3 py-2 bg-indigo-50 rounded-lg">
         <span className="text-xs text-gray-600">총 지출</span>
         <span className="text-md sm:text-lg font-bold text-primary-text">
           {totalSpend.toLocaleString()}
-          <span className="hidden sm:inline">원</span>
+          <span className="hidden sm:inline"> {currencyCode}</span>
         </span>
       </div>
     </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 여행의 국가별로 적절한 환율 코드를 자동으로 인식하여 지출 통계, 차트, 지출 목록 등 모든 관련 페이지에 동적으로 표시합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->