### PR TITLE
refactor: 반응형에 따른 레이아웃 크기 조정

### DIFF
--- a/src/components/auth/LogoutButton.tsx
+++ b/src/components/auth/LogoutButton.tsx
@@ -15,7 +15,7 @@ export default function LogoutButton() {
   return (
     <button
       onClick={handleLogout}
-      className="px-3 py-1.5 text-xs sm:text-sm sm:px-8 sm:py-3 bg-red-500 text-white rounded"
+      className="px-6 py-2.5 text-sm sm:text-sm sm:px-8 sm:py-3 bg-red-500 text-white rounded"
     >
       로그아웃
     </button>

--- a/src/components/form/SpendInputForm.tsx
+++ b/src/components/form/SpendInputForm.tsx
@@ -51,7 +51,7 @@ export default function SpendInputForm({
 
         <select
           {...register('expense_method')}
-          className="flex-1 min-w-0 px-2 py-1.5 text-xs text-gray-600 bg-transparent border-0 focus:outline-none"
+          className="flex-1 min-w-0 px-2 py-2 text-sm text-gray-600 bg-transparent border-0 focus:outline-none"
         >
           <option value="">결제</option>
           <option value="cash">현금</option>
@@ -62,12 +62,12 @@ export default function SpendInputForm({
           {...register('amount', { valueAsNumber: true })}
           type="number"
           placeholder="금액"
-          className="flex-[1.5] min-w-0 px-2 py-1.5 text-xs text-right text-gray-600 placeholder:text-gray-400 bg-transparent border-0 focus:outline-none"
+          className="flex-[1.5] min-w-0 px-2 py-2 text-sm text-right text-gray-600 placeholder:text-gray-400 bg-transparent border-0 focus:outline-none"
         />
 
         <select
           {...register('category')}
-          className="flex-1 min-w-0 px-2 py-1.5 text-xs text-center text-gray-600 bg-transparent border-0 focus:outline-none"
+          className="flex-[1.2] min-w-[4rem] px-2 py-2 text-sm text-center text-gray-600 bg-transparent border-0 focus:outline-none"
         >
           <option value="">유형</option>
           <option value="식사">식사</option>
@@ -79,7 +79,7 @@ export default function SpendInputForm({
         <input
           {...register('memo')}
           placeholder="메모"
-          className="flex-[2.5] min-w-0 px-2 py-1.5 text-xs text-gray-600 placeholder:text-gray-400 bg-transparent border-0 focus:outline-none"
+          className="flex-[2] min-w-0 px-2 py-2 text-sm text-gray-600 placeholder:text-gray-400 bg-transparent border-0 focus:outline-none"
         />
 
         <button

--- a/src/components/spend/SpendItem.tsx
+++ b/src/components/spend/SpendItem.tsx
@@ -22,7 +22,7 @@ export default function SpendItem({
         </div>
 
         <div className="flex-[1.5] px-2 text-right font-semibold text-primary-text text-sm">
-          {spend.amount.toLocaleString()} {currencyCode}
+          {spend.amount.toLocaleString()}
         </div>
 
         <div className="flex-1 px-2 text-center">

--- a/src/components/spend/SpendList.tsx
+++ b/src/components/spend/SpendList.tsx
@@ -50,7 +50,7 @@ export default function SpendList({ tripId, data, selectedDay, currencyCode }: S
       />
       <div className="flex px-5 py-2 items-center text-xs text-gray-500 font-medium border-b border-gray-200 pr-[calc(1.25rem+15px)]">
         <div className="flex-1 px-3">결제</div>
-        <div className="flex-[1.5] px-3 text-right">금액</div>
+        <div className="flex-[1.5] px-3 text-right">금액({currencyCode})</div>
         <div className="flex-1 px-3 text-center">유형</div>
         <div className="flex-[2.5] px-3">메모</div>
       </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * 로그아웃 버튼의 패딩 및 글꼴 크기를 조정하여 더 나은 가시성을 제공합니다.
  * 지출 입력 폼의 컨트롤들(선택 항목, 입력 필드)의 글꼴 크기와 여백을 개선했습니다.
  * 지출 목록에서 통화 코드 표시 방식을 개선하여 금액 헤더에 통화 정보를 포함하도록 변경했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->