### PR TITLE
fix: 토큰 갱신 실패시 로그인 페이지로 이동

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -3,12 +3,15 @@ import { createContext, useEffect, useState } from 'react';
 import type { AuthContextType } from '../type/auth';
 import type { User } from '@supabase/supabase-js';
 import { createClient } from '../utils/supabase/client';
+import { useRouter } from 'next/navigation';
+import { ROOT_PATH } from '../constants/routes';
 
 export const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
+  const router = useRouter();
 
   useEffect(() => {
     const supabase = createClient();
@@ -20,12 +23,18 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
     const {
       data: { subscription },
-    } = supabase.auth.onAuthStateChange((_event, session) => {
+    } = supabase.auth.onAuthStateChange((event, session) => {
       setUser(session?.user ?? null);
+      if (event === 'TOKEN_REFRESHED' && !session) {
+        router.push(ROOT_PATH);
+      }
+      if (event === 'SIGNED_OUT') {
+        router.push(ROOT_PATH);
+      }
     });
 
     return () => subscription.unsubscribe();
-  }, []);
+  }, [router]);
 
   return <AuthContext.Provider value={{ user, setUser, loading }}>{children}</AuthContext.Provider>;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 인증 세션 토큰이 갱신될 때 자동으로 홈 화면으로 리디렉트되도록 개선
  * 로그아웃 시 자동으로 홈 화면으로 리디렉트되는 기능 추가
  * 인증 상태 변경 처리 로직 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->